### PR TITLE
Allow MFRC522_I2C to work without a reset pin

### DIFF
--- a/src/MFRC522_I2C.cpp
+++ b/src/MFRC522_I2C.cpp
@@ -203,7 +203,8 @@ void MFRC522_I2C::PCD_Init() {
 		else { // Perform a soft reset
 			PCD_Reset();
 		}
-	else { // Perform a soft reset
+	}
+	else {
 		// RST pin is not controlled by this library.
 		// Give the MFRC522 module some time after power-up so that VDD and
 		// the internal oscillator can settle, then issue a software reset to

--- a/src/MFRC522_I2C.cpp
+++ b/src/MFRC522_I2C.cpp
@@ -19,7 +19,7 @@
  * Prepares the output pins.
  */
 MFRC522_I2C::MFRC522_I2C(	byte chipAddress,
-					byte resetPowerDownPin,	///< Arduino pin connected to MFRC522's reset and power down input (Pin 6, NRSTPD, active low)
+					int8_t resetPowerDownPin,	///< Arduino pin connected to MFRC522's reset and power down input (Pin 6, NRSTPD, active low). Set to -1 if the reset/power-down pin is not connected or not used.
 					TwoWire *TwoWireInstance
 				) {
 	_chipAddress = (uint8_t) chipAddress;
@@ -190,16 +190,25 @@ byte MFRC522_I2C::PCD_CalculateCRC(	byte *data,		///< In: Pointer to the data to
  * Initializes the MFRC522 chip.
  */
 void MFRC522_I2C::PCD_Init() {
-	// Set the resetPowerDownPin as digital output, do not reset or power down.
-	pinMode(_resetPowerDownPin, OUTPUT);
+	if (_resetPowerDownPin >= 0) {
+		// Set the resetPowerDownPin as digital output, do not reset or power down.
+		pinMode(_resetPowerDownPin, OUTPUT);
 
 
-	if (digitalRead(_resetPowerDownPin) == LOW) {	//The MFRC522 chip is in power down mode.
-		digitalWrite(_resetPowerDownPin, HIGH);		// Exit power down mode. This triggers a hard reset.
-		// Section 8.8.2 in the datasheet says the oscillator start-up time is the start up time of the crystal + 37,74�s. Let us be generous: 50ms.
-		delay(100);
-	}
+		if (digitalRead(_resetPowerDownPin) == LOW) {	//The MFRC522 chip is in power down mode.
+			digitalWrite(_resetPowerDownPin, HIGH);		// Exit power down mode. This triggers a hard reset.
+			// Section 8.8.2 in the datasheet says the oscillator start-up time is the start up time of the crystal + 37,74�s. Let us be generous: 50ms.
+			delay(100);
+		}
+		else { // Perform a soft reset
+			PCD_Reset();
+		}
 	else { // Perform a soft reset
+		// RST pin is not controlled by this library.
+		// Give the MFRC522 module some time after power-up so that VDD and
+		// the internal oscillator can settle, then issue a software reset to
+		// bring the registers into a known state.
+		delay(50);
 		PCD_Reset();
 	}
 

--- a/src/MFRC522_I2C.h
+++ b/src/MFRC522_I2C.h
@@ -322,7 +322,7 @@ public:
 	// Functions for setting up the Arduino
 	/////////////////////////////////////////////////////////////////////////////////////
 	// MFRC522_I2C(byte chipAddress, byte resetPowerDownPin, TwoWire & TwoWireInstance = Wire);
-    MFRC522_I2C(byte chipAddress, byte resetPowerDownPin, TwoWire *TwoWireInstance = &Wire);
+    MFRC522_I2C(byte chipAddress, int8_t resetPowerDownPin = -1, TwoWire *TwoWireInstance = &Wire);
 
 	/////////////////////////////////////////////////////////////////////////////////////
 	// Basic interface functions for communicating with the MFRC522
@@ -404,7 +404,7 @@ public:
 
 private:
 	uint16_t _chipAddress;
-	byte _resetPowerDownPin;	// Arduino pin connected to MFRC522's reset and power down input (Pin 6, NRSTPD, active low)
+	int8_t _resetPowerDownPin;	// Arduino pin connected to MFRC522's reset and power down input (Pin 6, NRSTPD, active low)
 	TwoWire *_TwoWireInstance = NULL;	// TwoWire Instance
 	byte MIFARE_TwoStepHelper(byte command, byte blockAddr, long data);
 };


### PR DESCRIPTION
## Summary

This PR adds support for using `MFRC522_I2C` without a connected reset/power-down pin.

When `resetPowerDownPin` is set to `-1`, the library now treats the reset pin as unused and skips direct GPIO operations such as `pinMode()`, `digitalRead()`, and `digitalWrite()`.

Instead, it waits briefly for the MFRC522 to stabilize after power-up or wake-up, then performs a software reset over I2C.

## Motivation

Some I2C-based MFRC522 modules or Grove-style setups do not expose the MFRC522 `NRSTPD` pin to the host microcontroller.

In such configurations, requiring a valid reset pin makes the library harder to use even though the chip can still be initialized through I2C after power-up.

This change makes the reset pin optional while keeping the existing behavior unchanged when a valid reset pin is provided.

## Changes

- Allow `resetPowerDownPin = -1` to indicate that the reset/power-down pin is not connected or not used.
- Skip hardware reset GPIO handling when the reset pin is unset.
- Add a short stabilization delay before issuing a software reset via I2C.
- Preserve existing behavior for users who provide a valid reset pin.

## Compatibility

This change is intended to be backward compatible.

Existing sketches that pass a valid reset pin should continue to work as before.

## Notes

Without control of the `NRSTPD` pin, the library cannot perform a hardware reset.  
In this configuration, initialization relies on the MFRC522 being powered and responsive on the I2C bus so that a software reset can be issued.